### PR TITLE
[FEAT] #9 유저조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/homesool/controller/UserController.java
+++ b/src/main/java/org/sopt/homesool/controller/UserController.java
@@ -1,0 +1,26 @@
+package org.sopt.homesool.controller;
+
+import com.sun.net.httpserver.Authenticator;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.sopt.homesool.common.dto.ApiResponse;
+import org.sopt.homesool.common.dto.SuccessStatus;
+import org.sopt.homesool.controller.dto.response.UserResponseDto;
+import org.sopt.homesool.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/user")
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<UserResponseDto> read(@PathVariable Long userId) {
+        return ApiResponse.success(SuccessStatus.USER_FIND_SUCCESS, userService.findUserById(userId));
+    }
+
+
+}

--- a/src/main/java/org/sopt/homesool/controller/dto/response/UserResponseDto.java
+++ b/src/main/java/org/sopt/homesool/controller/dto/response/UserResponseDto.java
@@ -1,0 +1,44 @@
+package org.sopt.homesool.controller.dto.response;
+
+import lombok.*;
+import org.sopt.homesool.domain.Rank;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserResponseDto {
+    private Long id;
+    private String nickName;
+    private Rank userRank;
+    private int point;
+    private int coupon;
+    private int interest;
+    private int waiting;
+    private int finish;
+    private int ready;
+    private int delivering;
+    private int delivered;
+    private String address;
+    private String phoneNumber;
+
+    public static UserResponseDto of(Long id, String nickName, Rank userRank, int point, int coupon, int interest,
+                                     int waiting, int finish, int ready, int delivering, int delivered, String address,
+                                     String phoneNumber) {
+        return UserResponseDto.builder()
+                .id(id)
+                .nickName(nickName)
+                .userRank(userRank)
+                .point(point)
+                .coupon(coupon)
+                .interest(interest)
+                .waiting(waiting)
+                .finish(finish)
+                .ready(ready)
+                .delivering(delivering)
+                .delivered(delivered)
+                .address(address)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/homesool/domain/User.java
+++ b/src/main/java/org/sopt/homesool/domain/User.java
@@ -1,16 +1,18 @@
 package org.sopt.homesool.domain;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
 
     @Column(length = 15, nullable = false)
     private String nickName;
@@ -42,7 +44,7 @@ public class User {
     @Column(nullable = false)
     private int delivered;
 
-    @Column(length = 31, nullable = false)
+    @Column(nullable = false)
     private String address;
 
     @Column(length = 15, nullable = false)

--- a/src/main/java/org/sopt/homesool/infrastructure/UserRepository.java
+++ b/src/main/java/org/sopt/homesool/infrastructure/UserRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.homesool.infrastructure;
+
+import org.sopt.homesool.domain.User;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface UserRepository extends Repository<User, Long> {
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/org/sopt/homesool/service/UserService.java
+++ b/src/main/java/org/sopt/homesool/service/UserService.java
@@ -1,0 +1,36 @@
+package org.sopt.homesool.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.homesool.controller.dto.response.UserResponseDto;
+import org.sopt.homesool.domain.User;
+import org.sopt.homesool.infrastructure.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserResponseDto findUserById(Long id) {
+        User user = userRepository.findById(id).orElseThrow(()-> new IllegalArgumentException());
+        return UserResponseDto.builder()
+                .id(id)
+                .nickName(user.getNickName())
+                .userRank(user.getUserRank())
+                .point(user.getPoint())
+                .coupon(user.getCoupon())
+                .interest(user.getInterest())
+                .waiting(user.getWaiting())
+                .finish(user.getFinish())
+                .ready(user.getReady())
+                .delivering(user.getDelivering())
+                .delivered(user.getDelivered())
+                .address(user.getAddress())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
+}


### PR DESCRIPTION



## 🫧 작업한 내용
- user id 타입 변경
- UserResponseDto 작성
- UserRepository 작성
- UserService 작성
- UserController 작성
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

## 👻 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- User 도메인의 address column 길이 제한을 지워주었습니다.

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #9