### PR TITLE
[FIX] #28 - 유저 관심 상품 조회 response 수정

### DIFF
--- a/src/main/java/org/sopt/homesool/controller/dto/response/UserResponseDto.java
+++ b/src/main/java/org/sopt/homesool/controller/dto/response/UserResponseDto.java
@@ -13,7 +13,7 @@ public class UserResponseDto {
     private Rank userRank;
     private int point;
     private int coupon;
-    private int interest;
+    private long interest;
     private int waiting;
     private int finish;
     private int ready;
@@ -22,7 +22,7 @@ public class UserResponseDto {
     private String address;
     private String phoneNumber;
 
-    public static UserResponseDto of(Long id, String nickName, Rank userRank, int point, int coupon, int interest,
+    public static UserResponseDto of(Long id, String nickName, Rank userRank, int point, int coupon, long interest,
                                      int waiting, int finish, int ready, int delivering, int delivered, String address,
                                      String phoneNumber) {
         return UserResponseDto.builder()

--- a/src/main/java/org/sopt/homesool/domain/User.java
+++ b/src/main/java/org/sopt/homesool/domain/User.java
@@ -3,11 +3,13 @@ package org.sopt.homesool.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
     @Id
@@ -27,7 +29,7 @@ public class User {
     private int coupon;
 
     @Column(nullable = false)
-    private int interest;
+    private long interest;
 
     @Column(nullable = false)
     private int waiting;

--- a/src/main/java/org/sopt/homesool/service/AlcoholService.java
+++ b/src/main/java/org/sopt/homesool/service/AlcoholService.java
@@ -2,13 +2,11 @@ package org.sopt.homesool.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.homesool.controller.dto.response.ProductInquiryResponseDto;
-import org.sopt.homesool.controller.dto.response.ReviewDetailResponseDto;
 import org.sopt.homesool.controller.dto.response.AlcoholDetailResponseDto;
 import org.sopt.homesool.controller.dto.response.AlcoholResponseDto;
 import org.sopt.homesool.controller.dto.response.TagResponseDto;
 import org.sopt.homesool.domain.Alcohol;
 import org.sopt.homesool.domain.ProductInquiry;
-import org.sopt.homesool.domain.Review;
 import org.sopt.homesool.domain.Tags;
 import org.sopt.homesool.infrastructure.AlcoholRepository;
 import org.sopt.homesool.infrastructure.ProductInquiryRepository;

--- a/src/main/java/org/sopt/homesool/service/UserService.java
+++ b/src/main/java/org/sopt/homesool/service/UserService.java
@@ -2,28 +2,38 @@ package org.sopt.homesool.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.homesool.controller.dto.response.UserResponseDto;
+import org.sopt.homesool.domain.Alcohol;
 import org.sopt.homesool.domain.User;
+import org.sopt.homesool.infrastructure.AlcoholRepository;
 import org.sopt.homesool.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final AlcoholRepository alcoholRepository;
 
     @Transactional
     public UserResponseDto findUserById(Long id) {
         User user = userRepository.findById(id).orElseThrow(()-> new IllegalArgumentException());
+        long likeCount = alcoholRepository.findAll()
+                .stream()
+                .map(alcohol -> alcohol.isLike())
+                .filter(like -> like == true)
+                .count();
+
         return UserResponseDto.builder()
                 .id(id)
                 .nickName(user.getNickName())
                 .userRank(user.getUserRank())
                 .point(user.getPoint())
                 .coupon(user.getCoupon())
-                .interest(user.getInterest())
+                .interest(likeCount)
                 .waiting(user.getWaiting())
                 .finish(user.getFinish())
                 .ready(user.getReady())


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 유저 정보를 조회 API에서 interest값을 alcohol 테이블의 like가 true인 컬럼의 개수로 반환하도록 수정하였습니다.


<img width="450" alt="image" src="https://github.com/GOSOPT-CDS-Homesool/SERVER/assets/65678579/779dca1f-3229-4573-b4ed-ce201dcae76d">
<img width="250" alt="image" src="https://github.com/GOSOPT-CDS-Homesool/SERVER/assets/65678579/08518fa5-afef-4da7-9c43-fffd78c89b63">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #28